### PR TITLE
FIX omission of one item in test result

### DIFF
--- a/result-package.json
+++ b/result-package.json
@@ -44,6 +44,7 @@
   "redux": "4.0.4",
   "redux-thunk": "2.3.0",
   "reselect": "^4.0.0",
+  "regenerator-runtime": "^0.13.2",
   "resolve-pathname": "^2.2.0",
   "scheduler": "0.14.0",
   "symbol-observable": "^1.2.0",


### PR DESCRIPTION
regenerator-runtime is in the sample input as a nested dependency

adding it here to the sample output to check against